### PR TITLE
Slightly working again

### DIFF
--- a/lib/Audio/PortAudio.pm
+++ b/lib/Audio/PortAudio.pm
@@ -2,7 +2,7 @@ use v6;
 
 use NativeCall;
 
-module Audio::PortAudio;
+unit module Audio::PortAudio;
 
 constant FRAMES_PER_BUFFER = 256;
 constant SAMPLE_RATE = 44100e0;

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -1,0 +1,9 @@
+#!perl6
+
+use lib 'lib';
+use Test;
+
+use-ok('Audio::PortAudio', 'can use Audio::PortAudio ok');
+
+done;
+# vim: expandtab shiftwidth=4 ft=perl6

--- a/test.pl
+++ b/test.pl
@@ -35,7 +35,7 @@ my $out-params = PaStreamParameters.new(:device(Pa_GetDefaultOutputDevice), :cha
     :suggested-latency(0.05e0));
     #:suggested-latency(Pa_GetDeviceInfo(Pa_GetDefaultOutputDevice).default-low-output-latency));
 
-$err = Pa_OpenStream($stream, Nil, $out-params, SAMPLE_RATE, FRAMES_PER_BUFFER, paClipOff, Nil, Nil);
+$err = Pa_OpenStream($stream, PaStreamParameters, $out-params, SAMPLE_RATE, FRAMES_PER_BUFFER, paClipOff, CArray[Pointer]);
 say "open: " ~ Pa_GetErrorText($err);
 
 say "stream is $stream, stream[0] is $stream[0]";
@@ -47,12 +47,12 @@ my CArray[num32] $wave .= new;
 
 # sine
 for ^TABLE_SIZE {
-    my num32 $v = sin( ($_ / TABLE_SIZE) * pi * 2);
-    $wave[$_] = $v;
+    my $v = sin( ($_ / TABLE_SIZE) * pi * 2);
+    $wave[$_] = Num($v);
 }
 
-my int $left-phase = 0;
-my int $right-phase = 0;
+my Int $left-phase = 0;
+my Int $right-phase = 0;
 
 my CArray[CArray[num32]] $buffer .= new;
 my CArray[num32] $left .= new;
@@ -61,12 +61,13 @@ my CArray[num32] $right .= new;
 $buffer[0] = $left;
 $buffer[1] = $right;
 
-my int $j = 0;
-my $i = 0;
+my Int $j = 0;
+my Int $i = 0;
 while $j < (2 * SAMPLE_RATE / FRAMES_PER_BUFFER) {
     while $i < FRAMES_PER_BUFFER {
-        $left[$i] = $wave[$left-phase];
-        $right[$i] = $wave[$right-phase];
+        my $n-l = Num($wave[$left-phase]);
+        $left[$i] = $n-l;
+        $right[$i] = Num($wave[$right-phase]);
         $left-phase -= TABLE_SIZE if $left-phase >= TABLE_SIZE;
         $right-phase -= TABLE_SIZE if $right-phase >= TABLE_SIZE;
         $left-phase += 1;


### PR DESCRIPTION
Hi,
I took a quick poke at this.  The only real problem was the behaviour of NativeCall must have changed WRT passing NULL to the function - you need to use the plain type object as Nil can't masquerade as another type in the sameway any more.

There is a problem that appears to be related to the https://rt.perl.org/Ticket/Display.html?id=125408 around the line 68, and it can be worked round by setting MVM_SPESH_DISABLE=1 in the environment which is obviously sub-optimal.

I didn't probe too much deeper but here I was getting a buffer under-run in alsa, but I think that's down to how the data is being populated.
